### PR TITLE
Correct name of GitHub event for Pull requests

### DIFF
--- a/examples/policy/added_label.rego
+++ b/examples/policy/added_label.rego
@@ -1,7 +1,7 @@
 package github.notify
 
 notify[msg] {
-    input.name == "pull_requests"
+    input.name == "pull_request"
     input.event.action == "labeled"
     input.event.label.name == "breaking-change"
 


### PR DESCRIPTION
This PR fixes '`unknown X-Github-Event in message`' error when the policy `added_label.rego` is used