### PR TITLE
Upgrade go image to `1.20`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build-go
+FROM golang:1.20 AS build-go
 COPY . /src
 WORKDIR /src
 RUN go build -o ghnotify .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build-go
+FROM golang:1.20-bullseye AS build-go
 COPY . /src
 WORKDIR /src
 RUN go build -o ghnotify .


### PR DESCRIPTION
- Problem to solve: ghnotify should be based on Go image `1.20` to avoid build error on current `main` (e.g. https://github.com/m-mizutani/ghnotify/actions/runs/5418044198/jobs/9849714684 )
    - because module x/exp requires Go 1.20
- How I solved the problem in this PR: I `golang:1.20-bullseye` not mere `golang:1.20` for base Docker image  because the latter caused 'LIBGC not found' error when running ghnotify container
    - c.f. https://github.com/GoogleContainerTools/distroless/issues/1342
