### PR TITLE
Add endpoint `/health` for health checking

### DIFF
--- a/pkg/controller/server/healthcheck.go
+++ b/pkg/controller/server/healthcheck.go
@@ -1,0 +1,10 @@
+package server
+
+import "net/http"
+
+func handleHealthCheckRequest() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}
+}

--- a/pkg/controller/server/healthcheck_test.go
+++ b/pkg/controller/server/healthcheck_test.go
@@ -1,0 +1,20 @@
+package server_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/m-mizutani/ghnotify/pkg/controller/server"
+	"github.com/m-mizutani/ghnotify/pkg/usecase"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheck(t *testing.T) {
+	srv := server.New(&usecase.Usecase{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/health", nil)
+	srv.ServeHTTP(w, r)
+
+	assert.Equal(t, 200, w.Code)
+}

--- a/pkg/controller/server/server.go
+++ b/pkg/controller/server/server.go
@@ -32,6 +32,8 @@ func New(uc *usecase.Usecase) *Server {
 
 	r.Post("/webhook/github", serveGitHubWebhook(uc))
 
+	r.Get("/health", handleHealthCheckRequest())
+
 	return &Server{
 		uc:  uc,
 		mux: r,


### PR DESCRIPTION
- waiting for #3 to be merged

---
- related issue: #5

- summary: This pull request introduces a new endpoint `/health` to ghnotify
- spec: The `/health` endpoint is designed to respond to `GET` requests with a `200 OK` status code
