### PR TITLE
Upgrade go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build-go
+FROM golang:1.20 AS build-go
 COPY . /src
 WORKDIR /src
 RUN go build -o ghnotify .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.20-bullseye AS build-go
+FROM golang:1.20 AS build-go
 COPY . /src
 WORKDIR /src
-RUN go build -o ghnotify .
+RUN CGO_ENABLED=0 go build -o ghnotify .
 
 FROM gcr.io/distroless/base
 COPY --from=build-go /src/ghnotify /ghnotify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build-go
+FROM golang:1.20-bullseye AS build-go
 COPY . /src
 WORKDIR /src
 RUN go build -o ghnotify .


### PR DESCRIPTION
Based on #3 

- Use `golang:1.20` image
- set `CGO_ENABLED=0` to avoid glibc error

