### PR TITLE
Fix runtime error when setting logging params via environmental variables

### DIFF
--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -174,7 +174,7 @@ func Run(argv []string) error {
 				Name:        "log-format",
 				Category:    "logging",
 				Aliases:     []string{"f"},
-				Usage:       "Log format [text|json]",
+				Usage:       "Log format [console|json]",
 				EnvVars:     []string{"GHNOTIFY_LOG_FORMAT"},
 				Destination: &logFormat,
 				Value:       &logFormat,

--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -177,6 +177,7 @@ func Run(argv []string) error {
 				Usage:       "Log format [text|json]",
 				EnvVars:     []string{"GHNOTIFY_LOG_FORMAT"},
 				Destination: &logFormat,
+				Value:       &logFormat,
 			},
 			&cli.GenericFlag{
 				Name:        "log-output",
@@ -185,6 +186,7 @@ func Run(argv []string) error {
 				Usage:       "Log output [stdout|stderr]",
 				EnvVars:     []string{"GHNOTIFY_LOG_OUTPUT"},
 				Destination: &logOutput,
+				Value:       &logOutput,
 			},
 		},
 		Commands: []*cli.Command{

--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -168,6 +168,7 @@ func Run(argv []string) error {
 				Usage:       "Log level [debug|info|warn|error]",
 				EnvVars:     []string{"GHNOTIFY_LOG_LEVEL"},
 				Destination: &logLevel,
+				Value:       &logLevel,
 			},
 			&cli.GenericFlag{
 				Name:        "log-format",

--- a/pkg/controller/cmd/cli_test.go
+++ b/pkg/controller/cmd/cli_test.go
@@ -10,30 +10,60 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	t.Run("configure using environmental variable", func(t *testing.T) {
-		os.Setenv("GHNOTIFY_LOG_LEVEL", "debug")
-		defer os.Unsetenv("GHNOTIFY_LOG_LEVEL")
+	tests := []struct {
+		name     string
+		envKey   string
+		envValue string
+		port     string
+	}{
+		{
+			name:     "configure using GHNOTIFY_LOG_LEVEL",
+			envKey:   "GHNOTIFY_LOG_LEVEL",
+			envValue: "debug",
+			port:     "4080",
+		},
+		{
+			name:     "configure using GHNOTIFY_LOG_FORMAT",
+			envKey:   "GHNOTIFY_LOG_FORMAT",
+			envValue: "json",
+			port:     "4081",
+		},
+		{
+			name:     "configure using GHNOTIFY_LOG_OUTPUT",
+			envKey:   "GHNOTIFY_LOG_OUTPUT",
+			envValue: "stdout",
+			port:     "4082",
+		},
+	}
 
-		errCh := make(chan error)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(tt.envKey, tt.envValue)
+			defer os.Unsetenv(tt.envKey)
 
-		go func() {
-			argv := []string{
-				"ghnotify",
-				"--slack-api-token",
-				"dummy",
-				"--remote-url",
-				"localhost:1234",
-				"serve",
+			errCh := make(chan error)
+
+			go func() {
+				argv := []string{
+					"ghnotify",
+					"--slack-api-token",
+					"dummy",
+					"--remote-url",
+					"localhost:1234",
+					"serve",
+					"--addr",
+					"0.0.0.0:" + tt.port,
+				}
+				err := cmd.Run(argv)
+				errCh <- err
+			}()
+
+			select {
+			case err := <-errCh:
+				assert.NoError(t, err)
+			case <-time.After(time.Second * 1):
+				t.Log("cmd.Run exited without error")
 			}
-			err := cmd.Run(argv)
-			errCh <- err
-		}()
-
-		select {
-		case err := <-errCh:
-			assert.NoError(t, err)
-		case <-time.After(time.Duration(0.1 * float64(time.Second))):
-			t.Log("cmd.Run exited without error")
-		}
-	})
+		})
+	}
 }

--- a/pkg/controller/cmd/cli_test.go
+++ b/pkg/controller/cmd/cli_test.go
@@ -1,0 +1,39 @@
+package cmd_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/m-mizutani/ghnotify/pkg/controller/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("configure using environmental variable", func(t *testing.T) {
+		os.Setenv("GHNOTIFY_LOG_LEVEL", "debug")
+		defer os.Unsetenv("GHNOTIFY_LOG_LEVEL")
+
+		errCh := make(chan error)
+
+		go func() {
+			argv := []string{
+				"ghnotify",
+				"--slack-api-token",
+				"dummy",
+				"--remote-url",
+				"localhost:1234",
+				"serve",
+			}
+			err := cmd.Run(argv)
+			errCh <- err
+		}()
+
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err)
+		case <-time.After(time.Duration(0.1 * float64(time.Second))):
+			t.Log("cmd.Run exited without error")
+		}
+	})
+}

--- a/pkg/controller/cmd/cli_test.go
+++ b/pkg/controller/cmd/cli_test.go
@@ -60,7 +60,7 @@ func TestRun(t *testing.T) {
 				select {
 				case err := <-errCh:
 					assert.NoError(t, err)
-				case <-time.After(time.Second * 1):
+				case <-time.After(time.Duration(0.01 * float64(time.Second))):
 					t.Log("cmd.Run exited without error")
 				}
 			})

--- a/pkg/controller/cmd/cli_test.go
+++ b/pkg/controller/cmd/cli_test.go
@@ -24,7 +24,7 @@ func TestRun(t *testing.T) {
 			"error": EnvTest{"4084", "error"},
 		},
 		"GHNOTIFY_LOG_FORMAT": {
-			"text": EnvTest{"4085", "text"},
+			"text": EnvTest{"4085", "console"},
 			"json": EnvTest{"4086", "json"},
 		},
 		"GHNOTIFY_LOG_OUTPUT": {


### PR DESCRIPTION
- This PR resolves #8 

## What I did

- Main work
    - Set `Value` in each `GenericFlag` s for logging parameters https://github.com/m-mizutani/ghnotify/pull/7/commits/067f1fd7d9a3dc091d21a06659bf3f13f50371fa
- Other small fix
    - Corrected parameter value https://github.com/m-mizutani/ghnotify/pull/7/commits/228b5b751d6b446c0568b745fdf76d396a4d2faf

## What this PR brings

It enables us to set logging parameters via environmental variables