### PR TITLE
Accept `bool` type value for `NotifyField.Value`

### DIFF
--- a/pkg/controller/server/webhook_test.go
+++ b/pkg/controller/server/webhook_test.go
@@ -62,6 +62,10 @@ func TestWebhook(t *testing.T) {
 							Value: "blue",
 							URL:   "https://example.com",
 						},
+						{
+							Name:  "read_only",
+							Value: true,
+						},
 					},
 				},
 			},

--- a/pkg/domain/model/rego.go
+++ b/pkg/domain/model/rego.go
@@ -18,7 +18,7 @@ type Notify struct {
 }
 
 type NotifyField struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-	URL   string `json:"url"`
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+	URL   string      `json:"url"`
 }

--- a/pkg/usecase/github_event.go
+++ b/pkg/usecase/github_event.go
@@ -45,10 +45,21 @@ func (x *Usecase) HandleGitHubEvent(ctx *types.Context, eventType string, body [
 
 func toBlock(field *model.NotifyField) *slack.TextBlockObject {
 	text := fmt.Sprintf("*%s*: ", field.Name)
+
+	var valueStr string
+	switch v := field.Value.(type) {
+	case string:
+		valueStr = v
+	case bool:
+		valueStr = fmt.Sprintf("%v", v)
+	default:
+		valueStr = "unknown"
+	}
+
 	if field.URL != "" {
-		text += fmt.Sprintf("<%s|%s>", field.URL, field.Value)
+		text += fmt.Sprintf("<%s|%s>", field.URL, valueStr)
 	} else {
-		text += field.Value
+		text += valueStr
 	}
 	return slack.NewTextBlockObject(slack.MarkdownType, text, false, false)
 }


### PR DESCRIPTION
This PR resolves an error when [`deploy_key` event](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#deploy_key )  is POSTed to `ghnotify`

- resolve #11 
