### PR TITLE
Add endpoint `/metrics` to provide metrics to Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/m-mizutani/zlog v0.3.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/open-policy-agent/opa v0.52.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,11 +16,13 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:o
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -135,6 +137,7 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
+github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/open-policy-agent/opa v0.52.0 h1:Rv3F+VCDqsufaiYy/3S9/Iuk0yfcREK4iZmWbNsKZjA=
 github.com/open-policy-agent/opa v0.52.0/go.mod h1:2n99s7WY/BXZUWUOq10JdTgK+G6XM4FYGoe7kQ5Vg0s=

--- a/pkg/controller/server/server.go
+++ b/pkg/controller/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/m-mizutani/ghnotify/pkg/usecase"
 	"github.com/m-mizutani/ghnotify/pkg/utils"
 	"github.com/m-mizutani/goerr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/exp/slog"
 )
 
@@ -33,6 +34,8 @@ func New(uc *usecase.Usecase) *Server {
 	r.Post("/webhook/github", serveGitHubWebhook(uc))
 
 	r.Get("/health", handleHealthCheckRequest())
+
+	r.Get("/metrics", promhttp.Handler().ServeHTTP)
 
 	return &Server{
 		uc:  uc,

--- a/pkg/controller/server/server.go
+++ b/pkg/controller/server/server.go
@@ -31,11 +31,11 @@ func New(uc *usecase.Usecase) *Server {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(60 * time.Second))
 
-	r.Post("/webhook/github", serveGitHubWebhook(uc))
+	r.Post("/webhook/github", utils.MetricsMiddleware(serveGitHubWebhook(uc)).ServeHTTP)
 
 	r.Get("/health", handleHealthCheckRequest())
 
-	r.Get("/metrics", promhttp.Handler().ServeHTTP)
+	r.Get("/metrics", utils.MetricsMiddleware(promhttp.Handler()).ServeHTTP)
 
 	return &Server{
 		uc:  uc,

--- a/pkg/utils/monitoring.go
+++ b/pkg/utils/monitoring.go
@@ -32,6 +32,11 @@ func init() {
 	prometheus.MustRegister(httpResponseDuration)
 }
 
+func ResetMetrics() {
+	httpRequestCounterVec.Reset()
+	httpStatusCounterVec.Reset()
+}
+
 func MetricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {

--- a/pkg/utils/monitoring.go
+++ b/pkg/utils/monitoring.go
@@ -4,20 +4,32 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var httpStatusCounterVec = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "ghnotify_http_status_total",
-		Help: "Total number of HTTP responses, by status code.",
-	},
-	[]string{"code"},
+var (
+	httpStatusCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ghnotify_http_status_total",
+			Help: "Total number of HTTP responses, by status code.",
+		},
+		[]string{"code"},
+	)
+	httpResponseDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ghnotify_http_response_duration_seconds",
+			Help:    "Histogram of http response durations by status code.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"code"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(httpStatusCounterVec)
+	prometheus.MustRegister(httpResponseDuration)
 }
 
 func MetricsMiddleware(next http.Handler) http.Handler {
@@ -27,8 +39,10 @@ func MetricsMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		startTime := time.Now()
 		recorder := httptest.NewRecorder()
 		next.ServeHTTP(recorder, r)
+		duration := time.Since(startTime).Seconds()
 
 		for k, v := range recorder.HeaderMap {
 			w.Header()[k] = v
@@ -38,5 +52,6 @@ func MetricsMiddleware(next http.Handler) http.Handler {
 
 		httpStatus := strconv.Itoa(recorder.Code)
 		httpStatusCounterVec.WithLabelValues(httpStatus).Inc()
+		httpResponseDuration.WithLabelValues(httpStatus).Observe(duration)
 	})
 }

--- a/pkg/utils/monitoring.go
+++ b/pkg/utils/monitoring.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var httpStatusCounterVec = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "ghnotify_http_status_total",
+		Help: "Total number of HTTP responses, by status code.",
+	},
+	[]string{"code"},
+)
+
+func init() {
+	prometheus.MustRegister(httpStatusCounterVec)
+}
+
+func MetricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		recorder := httptest.NewRecorder()
+		next.ServeHTTP(recorder, r)
+
+		for k, v := range recorder.HeaderMap {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(recorder.Code)
+		w.Write(recorder.Body.Bytes())
+
+		httpStatus := strconv.Itoa(recorder.Code)
+		httpStatusCounterVec.WithLabelValues(httpStatus).Inc()
+	})
+}

--- a/pkg/utils/monitoring.go
+++ b/pkg/utils/monitoring.go
@@ -10,6 +10,13 @@ import (
 )
 
 var (
+	httpRequestCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ghnotify_http_request_total",
+			Help: "Total number of HTTP requests.",
+		},
+		[]string{"method"},
+	)
 	httpStatusCounterVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ghnotify_http_status_total",
@@ -28,6 +35,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(httpRequestCounterVec)
 	prometheus.MustRegister(httpStatusCounterVec)
 	prometheus.MustRegister(httpResponseDuration)
 }
@@ -56,6 +64,7 @@ func MetricsMiddleware(next http.Handler) http.Handler {
 		w.Write(recorder.Body.Bytes())
 
 		httpStatus := strconv.Itoa(recorder.Code)
+		httpRequestCounterVec.WithLabelValues(r.Method).Inc()
 		httpStatusCounterVec.WithLabelValues(httpStatus).Inc()
 		httpResponseDuration.WithLabelValues(httpStatus).Observe(duration)
 	})

--- a/pkg/utils/monitoring_test.go
+++ b/pkg/utils/monitoring_test.go
@@ -1,0 +1,55 @@
+package utils_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/m-mizutani/ghnotify/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	metricsHandler := utils.MetricsMiddleware(handler)
+
+	t.Run("metrics path should pass through", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+		assert.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		metricsHandler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "OK", recorder.Body.String())
+
+		metricName := "ghnotify_http_request_total"
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, metricName)
+		assert.Equal(t, 0, count)
+
+		metricName = "ghnotify_http_status_total"
+		count, err = testutil.GatherAndCount(prometheus.DefaultGatherer, metricName)
+		assert.Equal(t, 0, count)
+
+	})
+
+	t.Run("numbers of responses", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		assert.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		metricsHandler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "OK", recorder.Body.String())
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, "ghnotify_http_status_total")
+		assert.Equal(t, 1, count)
+	})
+}

--- a/pkg/utils/monitoring_test.go
+++ b/pkg/utils/monitoring_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestMetricsMiddleware(t *testing.T) {
+	utils.ResetMetrics()
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))


### PR DESCRIPTION
To resolve #14, I instrumented simple three metrics in `ghnotify`.

Metrics implemented by this PR (metrics type):
- `ghnotify_http_request_total` (counter)
- `ghnotify_http_status_total` (counter)
- `ghnotify_http_response_duration_seconds` (histogram)

---
- close #14 
